### PR TITLE
Allow back-off strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,36 @@ Call a promise-returning-function n times or until it resolves, otherwise reject
 const butYouPromised = require('but-you-promised');
 
 const randomlyRejectingPromise = () => {
-	const randomlyReject = Math.random() < 0.5;
+	const randomlyReject = Math.random() < 0.7;
+	
+	attemptsSoFar++;
+
+	console.log(`On attempt number ${attemptsSoFar}`);
+
 	return Promise[randomlyReject ? 'reject' : 'resolve']();
 };
 
+let attemptsSoFar = 0;
+
+const exponentialBackoff = ({ seedDelayInMs }) => {
+	return attemptsSoFar => {
+		const delayInMs = (attemptsSoFar * attemptsSoFar) * seedDelayInMs;
+
+		console.log(`⏳ Delaying by ${delayInMs} ms…`);
+
+		return delayInMs;
+	};
+};
+
 butYouPromised(randomlyRejectingPromise, {
+	backoffStrategy: exponentialBackoff({ // defaults to no delay, no backoff
+		seedDelayInMs: 1000
+	}),
 	data: {
 		parameter: 123
 	},
-	triesRemaining: 5
-}) 
+	triesRemaining: 10 // default is 5
+})
 .then(() => console.log('It resolved, eventually'))
-.catch(() => console.log('It failed after 5 attempts'));
+.catch(() => console.log('It failed after 10 attempts'));
 ```

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const defaults = {
+	backoffStrategy: () => 0,
 	triesRemaining: 5
 };
 
@@ -11,14 +12,22 @@ module.exports = (func, options) => {
 		return Promise.reject(new Error(`The first parameter should be a function, but it was type ${typeof func}`));
 	}
 
+	let attemptNum = 0;
+
 	const attempt = () => {
+		attemptNum++;
 		settings.triesRemaining--;
 
 		return func(settings.data)
 			.catch(err => {
 				if (settings.triesRemaining) {
-					return attempt();
-				}
+					return new Promise(resolve => {
+						setTimeout(
+							() => resolve(attempt()),
+							settings.backoffStrategy(attemptNum)
+						);
+					});
+				};
 
 				return Promise.reject(err);
 			});

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -98,4 +98,21 @@ describe('#butYouPromised', () => {
 			}
 		});
 	});
+
+	const exponentialDelay = ({ seedDelayInMs }) => {
+		return attemptsSoFar => (attemptsSoFar * attemptsSoFar) * seedDelayInMs;
+	};
+
+	it('allows a backoff strategy to be used when retrying', function () {
+		const startTime = Date.now();
+
+		return butYouPromised(rejectStub, {
+			backoffStrategy: exponentialDelay({ seedDelayInMs: 15 }),
+			triesRemaining: 4
+		}).catch(() => {
+			const timeDelta = Date.now() - startTime;
+			const expectedDelayFrom3Retries = 15 + 60 + 135;
+			expect(timeDelta).to.be.at.least(expectedDelayFrom3Retries);
+		});
+	});
 });


### PR DESCRIPTION
Usage: Bring your own back-off strategy and pass it in with the settings object as `backoffStrategy`. The module will call `backoffStrategy` before every retry in order to determine the delay before the next attempt is made.

See the README for a full example.