### PR TITLE
Allow custom predicate functions

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,7 +6,11 @@ const defaults = {
 	attemptsSoFar: 0,
 	backOffFunction: exponentialBackOff,
 	backOffSeedDelayInMs: 1000,
-	giveUpAfterAttempt: 5
+	giveUpAfterAttempt: 5,
+	onFulfilled: () => {},
+	onRejected: (err) => {
+		throw err;
+	}
 };
 
 class ParameterError extends Error {}
@@ -34,7 +38,10 @@ module.exports = (promiseReturningFunction, options) => {
 				? new Promise(handleSubsequentAttempts) : Promise.reject(err)
 		);
 
-		return promiseReturningFunction(...args).catch(handleRejection);
+		return promiseReturningFunction(...args)
+			.then(settings.onFulfilled)
+			.catch(settings.onRejected)
+			.catch(handleRejection);
 	};
 
 	return attempt;


### PR DESCRIPTION
Allows optional `onFulfilled` and `onRejected` functions to be passed in.

`onFulfilled`: A function that will be called internally if `yourFunction`’s promise is fulfilled. This is useful if you want to override what is deemed a successful scenario, such as a network request that returns a 500 response.

`onRejected`: A function that will be called internally every time `yourFunction`’s promise is rejected (if at all). This is useful if you want to override what is deemed a failure scenario, or if you want to log attempts.