### PR TITLE
Minor fixes 🤝

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ An object that can be passed-in to override default settings.
 
 	An integer that sets the maximum number of times `yourFunction` will be called before rejecting. The number set here will only ever be reached if your function’s promise consistently rejects.
 
+- `backOffSeedDelayInMs` _optional integer, the default is 1000_
+
+	An integer that sets the back off delayed seed in milliseconds. This can be used to set the delay when omitting the default `createBackOffFunction`
+
+	### Example with default back-off function
+
+	```js
+	const wrappedFunction = butYouPromised(yourFunction, {
+		backOffSeedDelayInMs: 2000,
+		giveUpAfterAttempt: 10
+	});
+	```
+
 - `createBackOffFunction` _optional function, the default creates an exponential delay function_
 
 	A function used internally to create a back-off strategy between attempts, when first wrapping `yourFunction`. When called, `createBackOffFunction` should return a new function (let’s call it Y here for clarity). Y should return an integer and will be called after each failed attempt, in order to determine the minimum number of milliseconds to wait before another attempt (unless `giveUpAfterAttempt` has been reached). Y will be called internally with one parameter, which is a count of how many attempts have been made so far. This gives you flexibility to define how your subsequent attempts are made.

--- a/main.js
+++ b/main.js
@@ -7,7 +7,7 @@ const defaults = {
 	backOffFunction: exponentialBackOff,
 	backOffSeedDelayInMs: 1000,
 	giveUpAfterAttempt: 5,
-	onFulfilled: () => {},
+	onFulfilled: result => result,
 	onRejected: (err) => {
 		throw err;
 	}

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -163,6 +163,16 @@ describe('But you promised', () => {
 				});
 		});
 
+		it('passes-through result for onFulfilled by default', () => {
+			const expectedResult = { status: 200 };
+			const resolvingPromiseResult = sinon.stub().resolves(expectedResult);
+			const wrappedFunction = butYouPromised(resolvingPromiseResult);
+
+			return wrappedFunction().then((result) => {
+				expect(result).to.deep.equal(expectedResult);
+			});
+		});
+
 		it('uses an exponentional back-off strategy by default', (done) => {
 			const wrappedFunction = butYouPromised(stubs.rejectingPromise);
 			const expectedDelays = [0, 1000, 5000, 14000, 30000];


### PR DESCRIPTION
- [x] Document: `backOffSeedDelayInMs`
- [x] `onFulfilled`: pass-through result by default